### PR TITLE
液态玻璃改版 v3.23.4 + 学校选择页搜索回车修复

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.shangkeschedule"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 114
-        versionName = "3.22.9"
+        versionCode = 119
+        versionName = "3.23.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -29,6 +29,7 @@
     <!-- Main Interface and Today's Schedule -->
     <string name="action_reset">Reset</string>
     <string name="floating_course_hint">Suspended. Swipe weeks and tap a blank space to drop.</string>
+    <string name="a11y_back_to_current_week">Back to this week</string>
     <string name="nav_today_schedule">Today</string>
     <string name="nav_course_schedule">Schedule</string>
     <string name="nav_settings">Settings</string>

--- a/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_recent_visit">最近访问</string>
     <string name="action_reset">重置</string>
     <string name="floating_course_hint">已挂起，左右滑周点击空白处放下</string>
+    <string name="a11y_back_to_current_week">回到本周</string>
 
     <!-- 主界面及今日课表 -->
     <string name="nav_today_schedule">今日课表</string>

--- a/shared/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -29,6 +29,7 @@
     <!-- 主介面及今日課表 -->
     <string name="action_reset">重置</string>
     <string name="floating_course_hint">已掛起，左右滑周點擊空白處放下</string>
+    <string name="a11y_back_to_current_week">回到本週</string>
     <string name="nav_today_schedule">今日課表</string>
     <string name="nav_course_schedule">課表</string>
     <string name="nav_settings">我的</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="label_recent_visit">最近访问</string>
     <string name="action_reset">重置</string>
     <string name="floating_course_hint">已挂起，左右滑周点击空白处放下</string>
+    <string name="a11y_back_to_current_week">回到本周</string>
 
     <!-- 主界面及今日课表 -->
     <string name="nav_today_schedule">今日课表</string>

--- a/shared/src/commonMain/kotlin/com/shangkeschedule/ui/components/NavigationComponents.kt
+++ b/shared/src/commonMain/kotlin/com/shangkeschedule/ui/components/NavigationComponents.kt
@@ -66,6 +66,7 @@ import com.shangkeschedule.ui.theme.AppShape
 import com.shangkeschedule.ui.theme.AppSpacing
 import com.shangkeschedule.ui.theme.AppType
 import com.shangkeschedule.ui.theme.appColors
+import com.shangkeschedule.ui.theme.liquidGlass
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import shangkeschedule.shared.generated.resources.Res
@@ -101,6 +102,12 @@ fun AdaptiveNavigationScaffold(
     bottomBarSelectedColor: Color? = null,
     bottomBarUnselectedColor: Color? = null,
     navigationModifier: Modifier = Modifier,
+    /**
+     * 底栏滚动隐藏状态回调：true 表示底栏已随下滑隐藏。
+     * 供页面内的悬浮控件（如课表页「回到本周」圆钮）与底栏同步下沉/淡出，
+     * 避免两套隐藏逻辑各自为政导致动画不同步。
+     */
+    onNavBarHiddenChange: (Boolean) -> Unit = {},
     content: @Composable (PaddingValues) -> Unit
 ) {
     val navItems = listOf(
@@ -253,6 +260,10 @@ fun AdaptiveNavigationScaffold(
                     barHidden = false
                     downAccumPx = 0f
                 }
+                // 同步隐藏状态给宿主页面内的悬浮控件
+                LaunchedEffect(barHidden) {
+                    onNavBarHiddenChange(barHidden)
+                }
                 val hideFraction by animateFloatAsState(
                     targetValue = if (barHidden) 1f else 0f,
                     animationSpec = tween(durationMillis = 220),
@@ -289,30 +300,14 @@ fun AdaptiveNavigationScaffold(
                     ) {
                         Row(
                             modifier = navigationModifier
-                                .shadow(
-                                    elevation = 14.dp,
+                                // 液态玻璃：毛玻璃 + 白纱 + 顶部高光 + 折射亮边（与「回到本周」圆钮同源），
+                                // 内部已按「shadow → clip → hazeEffect → 高光 → 亮边」顺序封装
+                                .liquidGlass(
+                                    hazeState = hazeState,
                                     shape = AppShape.capsule,
-                                    clip = false,
-                                    ambientColor = tokens.shadow,
-                                    spotColor = tokens.shadow
+                                    containerColor = bottomBarContainerColor ?: tokens.inputBg,
+                                    isTransparent = isTransparent
                                 )
-                                // 圆角修复：clip 必须排在 hazeEffect 之前——Modifier 链由外向内生效，
-                                // 玻璃层（hazeEffect）只有处于 clip 内部才会被裁成胶囊形，
-                                // 否则模糊+白 tint 以整节点矩形渲染，呈现「方形白条」。
-                                .clip(AppShape.capsule)
-                                .hazeEffect(hazeState) {
-                                    blurRadius = 20.dp
-                                    noiseFactor = 0.12f
-                                    tints = listOf(
-                                        if (isTransparent) HazeTint(Color.Transparent)
-                                        else HazeTint((bottomBarContainerColor ?: tokens.inputBg).copy(alpha = 0.70f))
-                                    )
-                                    fallbackTint = if (isTransparent) HazeTint(Color.Black.copy(alpha = 0.2f))
-                                    else HazeTint(bottomBarContainerColor ?: tokens.inputBg)
-                                    backgroundColor = Color.Transparent
-                                }
-                                .border(1.dp, tokens.divider.copy(alpha = 0.6f), AppShape.capsule)
-                                .background(if (isTransparent) Color.Transparent else (bottomBarContainerColor ?: tokens.inputBg).copy(alpha = 0.10f))
                                 .padding(horizontal = 10.dp, vertical = 7.dp),
                             horizontalArrangement = Arrangement.spacedBy(4.dp),
                             verticalAlignment = Alignment.CenterVertically

--- a/shared/src/commonMain/kotlin/com/shangkeschedule/ui/schedule/WeeklyScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shangkeschedule/ui/schedule/WeeklyScheduleScreen.kt
@@ -1,5 +1,10 @@
 package com.shangkeschedule.ui.schedule
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -10,34 +15,45 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ripple
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -56,6 +72,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.LayoutDirection
@@ -77,6 +94,7 @@ import com.shangkeschedule.ui.components.CourseTablePickerDialog
 import com.shangkeschedule.ui.components.TelegramMenu
 import com.shangkeschedule.ui.components.TelegramMenuDivider
 import com.shangkeschedule.ui.components.TelegramMenuItem
+import com.shangkeschedule.ui.components.rememberFabPressedScale
 import com.shangkeschedule.ui.schedule.components.CourseDetailBottomSheet
 import com.shangkeschedule.ui.schedule.components.FloatingCourseBar
 import com.shangkeschedule.ui.schedule.components.ScheduleGrid
@@ -88,12 +106,15 @@ import com.shangkeschedule.ui.schedule.components.rememberScheduleGridState
 import com.shangkeschedule.ui.schedule.components.adaptiveTextColor
 import com.shangkeschedule.ui.theme.AppAlpha
 import com.shangkeschedule.ui.theme.AppShape
+import com.shangkeschedule.ui.theme.AppSpacing
 import com.shangkeschedule.ui.theme.AppType
 import com.shangkeschedule.ui.theme.LocalIsDarkTheme
 import com.shangkeschedule.ui.theme.LocalThemePreset
 import com.shangkeschedule.ui.theme.TimetableDefaults
 import com.shangkeschedule.ui.theme.appColorTokens
 import com.shangkeschedule.ui.theme.appColors
+import com.shangkeschedule.ui.theme.liquidGlass
+import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -110,8 +131,10 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.koin.compose.viewmodel.koinViewModel
 import shangkeschedule.shared.generated.resources.Res
+import shangkeschedule.shared.generated.resources.a11y_back_to_current_week
 import shangkeschedule.shared.generated.resources.action_select_table
 import shangkeschedule.shared.generated.resources.arrow_drop_down_24px
+import shangkeschedule.shared.generated.resources.calendar_today_24px
 import shangkeschedule.shared.generated.resources.format_week_display
 import shangkeschedule.shared.generated.resources.label_view_mode_list
 import shangkeschedule.shared.generated.resources.label_view_mode_week
@@ -204,9 +227,39 @@ fun WeeklyScheduleScreen(
     var isGridHolding by remember { mutableStateOf(false) }
     var selectedBlockForDetail by remember { mutableStateOf<MergedCourseBlock?>(null) }
 
+    // 悬浮圆钮与玻璃底栏同步隐藏（同一套下滑手势语义，220ms 时长对齐底栏动画）
+    var isNavBarHidden by remember { mutableStateOf(false) }
+    val backToWeekHideFraction by animateFloatAsState(
+        targetValue = if (isNavBarHidden) 1f else 0f,
+        animationSpec = tween(durationMillis = 220),
+        label = "backToCurrentWeekHide"
+    )
+
+    // 圆钮停靠位：紧贴玻璃底栏容器上沿之上（语义与 AdaptiveNavigationScaffold 的
+    // barInsetBottom 一致：胶囊高 touchMin+14 + 上下 navBarBottom + 系统手势区）；
+    val density = LocalDensity.current
+    // 宽屏 Rail 形态无底部胶囊栏，直接贴屏幕右下，无需顶起预留高度。
+    val isRailLayout = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(
+        currentWindowAdaptiveInfo()
+    ) == NavigationSuiteType.NavigationRail
+    val navBarReserve = if (isRailLayout) {
+        0.dp
+    } else {
+        AppSpacing.touchMin + 14.dp + AppSpacing.navBarBottom * 2 +
+            (WindowInsets.navigationBars.getBottom(density) / density.density).dp
+    }
+
     val composedStyle = uiState.style
 
     val floatingCourse = uiState.floatingCourse
+
+    // 「回到本周」判定：无限分页以 INFINITE_PAGER_CENTER 承载「本周」，
+    // 因此页码离开中心页即代表用户已滑到非本周课程（拖动过程中即时显隐）。
+    // 课程挂起态（floatingCourse）下让位给 FloatingCourseBar，不显示圆钮。
+    val isOnCurrentWeekPage by remember {
+        derivedStateOf { pagerState.currentPage == INFINITE_PAGER_CENTER }
+    }
+    val showBackToCurrentWeek = floatingCourse == null && !isOnCurrentWeekPage
 
     // 悬浮面板玻璃：主内容 hazeSource（含壁纸），周选择面板背板模糊
     val hazeState = rememberHazeState()
@@ -259,6 +312,7 @@ fun WeeklyScheduleScreen(
         showNavigation = floatingCourse == null,
         isTransparent = composedStyle.backgroundImagePath.isNotEmpty(),
         contentColor = customTextColor,
+        onNavBarHiddenChange = { hidden -> isNavBarHidden = hidden },
         // P2-6 去除独立的 navigationModifier 滚动隐藏：AdaptiveNavigationScaffold 已内置
         // 统一的滚动隐藏连接（下滑累积隐藏 / 上滑 / 切 Tab / 顶部动画恢复），
         // 此处再叠加 collapseFraction 平移+alpha 会和内置隐藏产生双重位移/淡出叠加。
@@ -675,6 +729,24 @@ fun WeeklyScheduleScreen(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 24.dp)
             )
+            BackToCurrentWeekFab(
+                visible = showBackToCurrentWeek,
+                hideFraction = backToWeekHideFraction,
+                hideRange = navBarReserve + AppSpacing.cardGap + AppSpacing.touchMin,
+                hazeState = hazeState,
+                hasWallpaper = composedStyle.backgroundImagePath.isNotEmpty(),
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(INFINITE_PAGER_CENTER)
+                    }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(
+                        end = AppSpacing.navBarHorizontal,
+                        bottom = navBarReserve + AppSpacing.cardGap
+                    )
+            )
         }
     }
 
@@ -725,6 +797,74 @@ fun WeeklyScheduleScreen(
     }
 }
 
+
+/**
+ * 「回到本周」悬浮圆钮：仅在用户滑动到非本周课程时出现（右下角小圆圈），
+ * 点击回到本周所处页。
+ *
+ * 隐藏行为与玻璃底栏一致：[hideFraction] 由 AdaptiveNavigationScaffold 的滚动隐藏
+ * 状态驱动，圆钮随之下沉 + 淡出：[hideRange] 覆盖「底栏预留高度 + 自身高度」，
+ * 保证隐藏动画结束时完全移出屏幕，不会残留半截圆钮。
+ */
+@Composable
+private fun BackToCurrentWeekFab(
+    visible: Boolean,
+    hideFraction: Float,
+    hideRange: Dp,
+    hazeState: HazeState,
+    hasWallpaper: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hideRangePx = with(LocalDensity.current) { hideRange.toPx() }
+    Box(
+        modifier = modifier.graphicsLayer {
+            translationY = hideFraction * hideRangePx
+            alpha = 1f - hideFraction
+        }
+    ) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn() + scaleIn(initialScale = 0.8f),
+            exit = fadeOut() + scaleOut(targetScale = 0.8f)
+        ) {
+            val interaction = remember { MutableInteractionSource() }
+            val pressedScale = rememberFabPressedScale(interaction)
+            Box(
+                modifier = Modifier
+                    .size(AppSpacing.touchMin)
+                    .graphicsLayer {
+                        scaleX = pressedScale
+                        scaleY = pressedScale
+                    }
+                    // 液态玻璃：与玻璃底栏胶囊同源（连续统一的玻璃语言）
+                    .liquidGlass(
+                        hazeState = hazeState,
+                        shape = CircleShape,
+                        containerColor = appColors().inputBg,
+                        // 壁纸模式下玻璃透出壁纸并补一层暗 scrim，保证图标可读
+                        isTransparent = hasWallpaper,
+                        shadowElevation = 8.dp,
+                        // 圆钮本身就是「按钮」形态，透明度按 LiquidButton 的取向取值
+                        blurRadius = 4.dp
+                    )
+                    .clickable(
+                        interactionSource = interaction,
+                        indication = ripple(bounded = true),
+                        onClick = onClick
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = vectorResource(Res.drawable.calendar_today_24px),
+                    contentDescription = stringResource(Res.string.a11y_back_to_current_week),
+                    tint = appColors().primary,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+        }
+    }
+}
 
 /**
  * 参考 sleepy 的列表视图：按天分组展示本周课程。

--- a/shared/src/commonMain/kotlin/com/shangkeschedule/ui/schoolselection/list/SchoolSelectionListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shangkeschedule/ui/schoolselection/list/SchoolSelectionListScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -328,6 +329,8 @@ fun SearchBarWithTitle(
     filteredSchools: List<School>,
     onSchoolSelected: (School) -> Unit
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     SearchBar(
         modifier = Modifier.fillMaxWidth(),
         // Telegram 全圆角浅灰胶囊搜索框（v2 规范 §4.3，页面已有搜索能力才换肤）
@@ -336,7 +339,20 @@ fun SearchBarWithTitle(
             SearchBarDefaults.InputField(
                 query = searchQuery,
                 onQueryChange = onQueryChange,
-                onSearch = { onSearchActiveChange(false) },
+                // 回车＝执行搜索：保留关键词并让结果列表继续可见。
+                // 旧实现是 onSearchActiveChange(false)，而"收起搜索条"在本页会连带把 query 清空，
+                // 于是按回车后搜索结果直接消失，表现为"等于没搜索"。
+                // 只有空查询（确实无可搜内容）时才收起。
+                onSearch = { query ->
+                    if (query.isBlank()) {
+                        onSearchActiveChange(false)
+                    } else {
+                        // 桌面端可能在折叠态用物理键盘输入，先展开保证结果可见
+                        if (!searchActive) onSearchActiveChange(true)
+                        // 收起软键盘，避免键盘挡住结果列表；输入框仍持有焦点，可继续改词
+                        keyboardController?.hide()
+                    }
+                },
                 expanded = searchActive,
                 onExpandedChange = onSearchActiveChange,
                 placeholder = { Text(if (searchActive) placeholderText else titleText) },

--- a/shared/src/commonMain/kotlin/com/shangkeschedule/ui/theme/LiquidGlass.kt
+++ b/shared/src/commonMain/kotlin/com/shangkeschedule/ui/theme/LiquidGlass.kt
@@ -1,0 +1,189 @@
+package com.shangkeschedule.ui.theme
+
+import androidx.compose.foundation.border
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+
+/**
+ * 玻璃本体的冷灰基色：只做极淡混入，让玻璃在纯白内容上比背景略沉一档，
+ * 从而显出轮廓与体积（避免暖色污染主题，故选中性偏冷的石板色）。
+ */
+private val LiquidGlassBodyScrim = Color(0xFF0B1A2B)
+
+/**
+ * 液态玻璃（Liquid Glass）修饰符：给悬浮层（玻璃底栏胶囊 / 「回到本周」圆钮等）
+ * 提供统一的玻璃观感。
+ *
+ * 设计参照 Kyant/backdrop（LiquidBottomTabs）的光学结构，并按本项目需求反向调参：
+ * 该库用 `blur(8dp) + lens(24dp, 24dp) + vibrancy()` —— 即**液体感主要来自折射位移光学，
+ * 而非模糊**；本项目要求「少一点模糊变形、多一点透明感」，因此：
+ * - **不做 lens 位移**（那正是"变形"的来源），只保留轻微 blur 提供雾度；
+ * - 表面基色 alpha 由 0.40 降到约 0.22，让底层内容更多透上来；
+ * - 所有高光改用 **BlendMode.Plus**（只加亮、不遮盖），这是"既亮又透"的关键：
+ *   SrcOver 的白渐变会把底下内容糊住，Plus 只是在原有像素上叠加亮度。
+ *
+ * 玻璃的四层光学（无透镜版）：
+ * 1. 投影：把玻璃从底层内容上托起来；
+ * 2. 外轮廓线：形状之外的半环（clip 之前绘制），纯白底色上的「存在线」；
+ * 3. 中心区：低 alpha 基色 + 低半径模糊，**保持通透**；
+ * 4. 边缘光学：贴边暗环 + 内壁亮环（Stroke）+ 45° 斜向 sheen + 上下内壁光，
+ *    全部集中在边缘几像素／窄带内，中心不覆盖。
+ */
+@Composable
+fun Modifier.liquidGlass(
+    hazeState: HazeState,
+    shape: Shape,
+    containerColor: Color,
+    isTransparent: Boolean = false,
+    shadowElevation: Dp = 14.dp,
+    blurRadius: Dp = 6.dp,
+    enabled: Boolean = true
+): Modifier {
+    if (!enabled) return this
+
+    val tokens = appColors()
+    val isDark = LocalIsDarkTheme.current
+
+    // 表面不透明度：对齐 backdrop 的 LiquidButton（其 surface 默认为 Unspecified，
+    // 即一块色都不画）。这里做不到完全不画（否则在纯白底色上形状会彻底消失、
+    // 也不利于图标可读性），故只保留刚够压住噪点的一档，形态辨识交给边缘光学。
+    val baseAlpha = if (isTransparent) 0.10f else if (isDark) 0.16f else 0.07f
+    val veilAlpha = if (isTransparent) 0.04f else if (isDark) 0.04f else 0.03f
+    val bodyScrim = if (isTransparent) 0.12f else if (isDark) 0.04f else 0.01f
+
+    // 边缘光学力度：混合模式必须是 Screen 而非 Plus——Plus 直接把 RGB 相加，
+    // 浅色内容上会瞬间顶到 255 纯白，把底下内容洗掉（实测 2217-2230 全为 255 的教训）。
+    // Screen 是饱和式加亮（1-(1-a)(1-b)），越亮加得越少，既立体又保留内容层次。
+    val sheenAlpha = if (isDark) 0.08f else 0.12f
+    val topInnerAlpha = if (isDark) 0.12f else 0.26f
+    val bottomInnerAlpha = if (isDark) 0.08f else 0.15f
+    val specularAlpha = if (isDark) 0.08f else 0.16f
+    // 表面几乎不再遮盖，玻璃的存在感改由边缘光学承担：亮环与暗环力度都要上调
+    val rimBright = if (isDark) 0.34f else 0.88f
+    val rimDim = if (isDark) 0.07f else 0.18f
+    val rimMid = if (isDark) 0.18f else 0.52f
+    // 贴边暗环：玻璃与外界折射的最外一圈，浅色背景上给玻璃"边界感"
+    val edgeShade = if (isDark) 0.34f else 0.16f
+    val outlineAlpha = if (isTransparent) 0.26f else if (isDark) 0.34f else 0.14f
+    val rimWidth = 1.1.dp
+
+    return this
+        .shadow(
+            elevation = shadowElevation,
+            shape = shape,
+            ambientColor = tokens.shadow,
+            spotColor = tokens.shadow
+        )
+        // 外轮廓线：排在 clip 之前，保留形状外的半环
+        .border(width = 1.dp, color = Color.Black.copy(alpha = outlineAlpha), shape = shape)
+        .clip(shape)
+        .hazeEffect(hazeState) {
+            this.blurRadius = blurRadius
+            noiseFactor = if (isTransparent) 0.10f else 0.06f
+            tints = listOf(
+                HazeTint(containerColorOrBlack(containerColor, isTransparent).copy(alpha = baseAlpha)),
+                HazeTint(LiquidGlassBodyScrim.copy(alpha = bodyScrim)),
+                HazeTint(Color.White.copy(alpha = veilAlpha))
+            )
+            fallbackTint = HazeTint(
+                containerColorOrBlack(containerColor, isTransparent)
+                    .copy(alpha = (baseAlpha + 0.24f).coerceAtMost(0.92f))
+            )
+            backgroundColor = Color.Transparent
+        }
+        // 边缘光学：全部用 Screen 加亮、且只覆盖边缘窄带 / 左上角小椭圆，
+        // 中心区域一律留空，保证底层内容清晰透出（透明感的第一优先级）。
+        .drawBehind {
+            // ① 45° 斜向 sheen：一条斜穿的极淡亮带，液体的镜面反光感
+            drawRect(
+                brush = Brush.linearGradient(
+                    0.00f to Color.Transparent,
+                    0.40f to Color.White.copy(alpha = sheenAlpha),
+                    0.50f to Color.White.copy(alpha = sheenAlpha * 0.4f),
+                    0.60f to Color.Transparent,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, 0f)
+                ),
+                blendMode = BlendMode.Screen
+            )
+            // ② 左上角小椭圆镜面光：范围收得比整宽小得多，不铺满整个面
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        Color.White.copy(alpha = specularAlpha),
+                        Color.White.copy(alpha = 0f)
+                    ),
+                    center = Offset(size.width * 0.22f, -size.height * 0.35f),
+                    radius = size.height * 0.95f
+                ),
+                blendMode = BlendMode.Screen
+            )
+            // ③ 上内壁窄亮带（仅上部 14%）
+            drawRect(
+                brush = Brush.verticalGradient(
+                    0f to Color.White.copy(alpha = topInnerAlpha),
+                    0.06f to Color.White.copy(alpha = topInnerAlpha * 0.5f),
+                    0.14f to Color.Transparent
+                ),
+                blendMode = BlendMode.Screen
+            )
+            // ④ 下内壁窄反光（仅下部 10%）
+            drawRect(
+                brush = Brush.verticalGradient(
+                    0.90f to Color.Transparent,
+                    1f to Color.White.copy(alpha = bottomInnerAlpha)
+                ),
+                blendMode = BlendMode.Screen
+            )
+        }
+        // 边缘三层光学（clip 已裁掉形状外的一半描边，所以每条 border 只留内侧一半）：
+        // 由外到内依次绘制「宽(V) → 中(亮) → 窄(暗)」，后者覆盖前者的内侧部分，
+        // 最终从形状边缘向内形成「暗环 → 亮环 → 柔和光晕」的层递，即玻璃厚度感。
+        .border(
+            width = rimWidth * 2.6f,
+            brush = Brush.linearGradient(
+                colors = listOf(
+                    Color.White.copy(alpha = rimDim),
+                    Color.White.copy(alpha = rimDim * 0.6f),
+                    Color.White.copy(alpha = rimMid * 0.5f)
+                ),
+                start = Offset.Zero,
+                end = Offset.Infinite
+            ),
+            shape = shape
+        )
+        .border(
+            width = rimWidth * 1.8f,
+            brush = Brush.linearGradient(
+                colors = listOf(
+                    Color.White.copy(alpha = rimBright),
+                    Color.White.copy(alpha = rimDim),
+                    Color.White.copy(alpha = rimMid)
+                ),
+                start = Offset.Zero,
+                end = Offset.Infinite
+            ),
+            shape = shape
+        )
+        .border(
+            width = rimWidth,
+            color = Color.Black.copy(alpha = edgeShade),
+            shape = shape
+        )
+}
+
+private fun containerColorOrBlack(containerColor: Color, isTransparent: Boolean): Color =
+    if (isTransparent) Color.Black else containerColor


### PR DESCRIPTION
## Summary
- 课表页新增「回到本周」悬浮圆钮：仅滑到非本周时出现，与玻璃底栏同步下沉/淡出；新增共用 liquidGlass 修饰符，底栏胶囊与圆钮统一玻璃光学语言（v3.22.9→v3.23.4，versionCode 119）
- 修复学校选择页搜索「回车等于没搜索」：回车改为执行搜索，保留关键词与结果列表并收起软键盘，仅空查询时收起搜索条

## Test plan
- [x] 真机（arm64）安装启动无崩溃
- [x] 毛玻璃底栏：胶囊形态、选中态高亮、内容玻璃后透出
- [x] 搜索回车：非空查询（aqzy / 南通大学）保留结果；空查询回车收起搜索
- [x] 回到本周圆钮：滑到下周出现、点击回本周、本周时隐藏
