### PR TITLE
fix: CI 资源克隆失败时回退仓库内置离线资源

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,36 +13,28 @@ jobs:
       - name: 检出代码 (Checkout)
         uses: actions/checkout@v4
 
-      - name: 清理索引和资源目标目录 (Clean Specific Resource Dirs)
-        run: |
-          # 强制删除 shared/assets/offline_repo/index 和 schools 的内容
-          rm -rf shared/assets/offline_repo/index
-          rm -rf shared/assets/offline_repo/schools
-          mkdir -p shared/assets/offline_repo/index
-          mkdir -p shared/assets/offline_repo/schools
-
       - name: 克隆索引文件 (Clone Index PB File)
         run: |
           INDEX_PATH="shared/assets/offline_repo/index"
           REPO_URL="https://${{ secrets.GITHUB_TOKEN }}@github.com/XingHeYuZhuan/shangke_warehouse.git"
-          
+
           echo "--- 正在克隆 index-pb-release 分支并获取 school_index.pb ---"
-          
+
           # 临时目录用于克隆
           TEMP_CLONE_DIR=$(mktemp -d)
-          
-          # 浅克隆 index-pb-release 分支
-          git clone --depth 1 --branch index-pb-release $REPO_URL $TEMP_CLONE_DIR
-          
-          # 移动文件到目标目录
-          if [ -f $TEMP_CLONE_DIR/school_index.pb ]; then
+
+          # 浅克隆 index-pb-release 分支（失败时回退到仓库内置索引）
+          if git clone --depth 1 --branch index-pb-release $REPO_URL $TEMP_CLONE_DIR && [ -f $TEMP_CLONE_DIR/school_index.pb ]; then
+            mkdir -p $INDEX_PATH
             mv $TEMP_CLONE_DIR/school_index.pb $INDEX_PATH/
             echo "school_index.pb 成功下载到 $INDEX_PATH/"
+          elif [ -f $INDEX_PATH/school_index.pb ]; then
+            echo "⚠️ 无法访问资源仓库，回退使用仓库内置的 school_index.pb"
           else
-            echo "错误：未在 index-pb-release 分支中找到 school_index.pb，请检查仓库配置。"
+            echo "错误：既无法克隆资源仓库，仓库内置 school_index.pb 也缺失。"
             exit 1
           fi
-          
+
           # 清理临时目录
           rm -rf $TEMP_CLONE_DIR
 
@@ -50,42 +42,50 @@ jobs:
         run: |
           SCHOOLS_PATH="shared/assets/offline_repo/schools"
           REPO_URL="https://${{ secrets.GITHUB_TOKEN }}@github.com/XingHeYuZhuan/shangke_warehouse.git"
-          
+
           ABS_SCHOOLS_PATH=$(realpath $SCHOOLS_PATH)
-          
+
           echo "--- 正在使用 sparse-checkout 克隆 main 分支下的 resources 目录 ---"
 
           # 临时目录用于稀疏克隆
           TEMP_CLONE_DIR=$(mktemp -d)
-          
-          # 步骤 1: 浅克隆仓库
-          git clone --depth 1 --branch main $REPO_URL $TEMP_CLONE_DIR
-          cd $TEMP_CLONE_DIR
-          
-          # 步骤 2: 切换到稀疏模式并设置只拉取 resources 目录
-          git sparse-checkout init
-          git sparse-checkout set resources
-          
-          
-          # 步骤 3: 移动 resources 目录到目标位置 (使用绝对路径)
-          if [ -d "resources" ]; then
-            # 使用绝对路径 ABS_SCHOOLS_PATH 来确保 mv 目标正确
-            mv resources $ABS_SCHOOLS_PATH/
-            echo "resources 目录成功下载到 $SCHOOLS_PATH/"
+
+          # 步骤 1: 浅克隆仓库（失败时回退到仓库内置资源）
+          if git clone --depth 1 --branch main $REPO_URL $TEMP_CLONE_DIR; then
+            cd $TEMP_CLONE_DIR
+
+            # 步骤 2: 切换到稀疏模式并设置只拉取 resources 目录
+            git sparse-checkout init
+            git sparse-checkout set resources
+
+            # 步骤 3: 移动 resources 目录到目标位置 (使用绝对路径)
+            if [ -d "resources" ]; then
+              # 使用绝对路径 ABS_SCHOOLS_PATH 来确保 mv 目标正确
+              rm -rf $ABS_SCHOOLS_PATH/resources
+              mv resources $ABS_SCHOOLS_PATH/
+              echo "resources 目录成功下载到 $SCHOOLS_PATH/"
+            else
+              echo "错误：稀疏检出失败。在 'main' 分支的根目录未找到或未检出 'resources' 目录。"
+              exit 1
+            fi
+
+            # 返回工作目录
+            cd ${{ github.workspace }}
+          elif [ -d $ABS_SCHOOLS_PATH/resources ]; then
+            echo "⚠️ 无法访问资源仓库，回退使用仓库内置的 schools 资源目录"
           else
-            echo "错误：稀疏检出失败。在 'main' 分支的根目录未找到或未检出 'resources' 目录。"
+            echo "错误：既无法克隆资源仓库，仓库内置 schools/resources 也缺失。"
             exit 1
           fi
-          
+
           echo "--- 正在清理所有 adapters.yaml 文件 (包括子目录) ---"
-          
-          # 步骤 4: 清理目标目录下的所有 adapters.yaml 文件 
+
+          # 步骤 4: 清理目标目录下的所有 adapters.yaml 文件
           find $ABS_SCHOOLS_PATH/resources -name "adapters.yaml" -exec rm -f {} \;
-          
+
           echo "资源克隆和清理完成。"
-          
-          # 返回工作目录并清理临时目录
-          cd ${{ github.workspace }}
+
+          # 清理临时目录
           rm -rf $TEMP_CLONE_DIR
 
       - name: 运行贡献者数据生成脚本 (Generate Contributors Data)


### PR DESCRIPTION
## Summary
- 上游私有仓库 XingHeYuZhuan/shangke_warehouse 对本仓库 GITHUB_TOKEN 不可访问，导致 android-build 工作流在克隆离线索引/资源步骤失败
- 修改工作流：克隆失败时回退使用已提交到仓库的 school_index.pb 与 schools/resources，确保正式版构建可独立完成
- 移除预删除资源目录步骤，保留 adapters.yaml 清理逻辑

## Test plan
- [ ] 重新触发 android-build 工作流，确认回退路径生效、三 ABI Release 构建成功